### PR TITLE
fixed browser binary setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,13 @@
 # selenide-allure-testNG-tests
 UI tests with selenide, allure and testNG in JAVA
+
+Modify run either by commandline options like:
+
+`-Dselenide.browser=chrome`
+
+or testNG suites like:
+
+`mvn clean test -DsuiteXmlFile=testng.xml`
+
+following setup: `mvn clean test allure:serve`
+will continously serve allure report under your IP at standard allure port.

--- a/pom.xml
+++ b/pom.xml
@@ -8,77 +8,95 @@
     <artifactId>allure-html-documentation</artifactId>
     <version>1.0-SNAPSHOT</version>
 
+    <properties>
+        <commonsio.version>2.6</commonsio.version>
+        <reflections.version>0.9.11</reflections.version>
+        <assertj.version>3.13.2</assertj.version>
+        <selenide.version>5.2.8</selenide.version>
+        <selenium.version>3.141.59</selenium.version>
+        <guava.version>25.1-jre</guava.version>
+        <allure.version>2.12.1</allure.version>
+        <j2html.version>1.4.0</j2html.version>
+        <testng.version>6.14.3</testng.version>
+        <lombok.version>1.18.8</lombok.version>
+        <slf4j.version>1.7.25</slf4j.version>
+        <jackson.version>2.9.6</jackson.version>
+        <aspectj.version>1.9.4</aspectj.version>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <maven.compiler.source>11</maven.compiler.source>
+        <maven.compiler.target>11</maven.compiler.target>
+    </properties>
 
     <dependencies>
         <dependency>
             <groupId>commons-io</groupId>
             <artifactId>commons-io</artifactId>
-            <version>2.6</version>
+            <version>${commonsio.version}</version>
         </dependency>
         <dependency>
             <groupId>org.reflections</groupId>
             <artifactId>reflections</artifactId>
-            <version>0.9.11</version>
+            <version>${reflections.version}</version>
         </dependency>
         <dependency>
             <groupId>org.assertj</groupId>
             <artifactId>assertj-core</artifactId>
-            <version>3.13.2</version>
+            <version>${assertj.version}</version>
         </dependency>
         <dependency>
             <groupId>com.codeborne</groupId>
             <artifactId>selenide</artifactId>
-            <version>5.2.8</version>
+            <version>${selenide.version}</version>
         </dependency>
         <dependency>
             <groupId>org.seleniumhq.selenium</groupId>
             <artifactId>selenium-java</artifactId>
-            <version>3.141.59</version>
+            <version>${selenium.version}</version>
         </dependency>
         <dependency>
             <groupId>com.google.guava</groupId>
             <artifactId>guava</artifactId>
-            <version>25.1-jre</version>
+            <version>${guava.version}</version>
         </dependency>
         <dependency>
             <groupId>io.qameta.allure</groupId>
             <artifactId>allure-testng</artifactId>
-            <version>2.12.1</version>
+            <version>${allure.version}</version>
         </dependency>
         <dependency>
             <groupId>com.j2html</groupId>
             <artifactId>j2html</artifactId>
-            <version>1.4.0</version>
+            <version>${j2html.version}</version>
         </dependency>
         <dependency>
             <groupId>org.testng</groupId>
             <artifactId>testng</artifactId>
-            <version>6.14.3</version>
+            <version>${testng.version}</version>
         </dependency>
         <dependency>
             <groupId>org.projectlombok</groupId>
             <artifactId>lombok</artifactId>
-            <version>1.18.8</version>
+            <version>${lombok.version}</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-api</artifactId>
-            <version>1.7.25</version>
+            <version>${slf4j.version}</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-simple</artifactId>
-            <version>1.7.25</version>
+            <version>${slf4j.version}</version>
         </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-annotations</artifactId>
-            <version>2.9.6</version>
+            <version>${jackson.version}</version>
         </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-core</artifactId>
-            <version>2.9.6</version>
+            <version>${jackson.version}</version>
         </dependency>
         <dependency>
             <groupId>org.aspectj</groupId>
@@ -86,14 +104,6 @@
             <version>${aspectj.version}</version>
         </dependency>
     </dependencies>
-
-    <properties>
-        <aspectj.version>1.9.1</aspectj.version>
-
-        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <maven.compiler.source>1.8</maven.compiler.source>
-        <maven.compiler.target>1.8</maven.compiler.target>
-    </properties>
 
 
     <build>
@@ -108,16 +118,14 @@
                 <artifactId>maven-surefire-plugin</artifactId>
                 <version>3.0.0-M3</version>
                 <configuration>
-
                     <suiteXmlFiles>
-                        <suiteXmlFile>${project.build.testSourceDirectory}/com/demo/project/ui/PresentationSuite.xml</suiteXmlFile>
+                        <suiteXmlFile>${project.basedir}/src/test/resources/testSuites/PresentationSuite.xml</suiteXmlFile>
                     </suiteXmlFiles>
 
                     <argLine>
                         -Dselenide.browser=firefox
                         -javaagent:"${settings.localRepository}/org/aspectj/aspectjweaver/${aspectj.version}/aspectjweaver-${aspectj.version}.jar"
                         -Dfile.encoding=UTF-8
-
                     </argLine>
                 </configuration>
             </plugin>

--- a/src/main/java/com/demo/project/listeners/DemoProjectListener.java
+++ b/src/main/java/com/demo/project/listeners/DemoProjectListener.java
@@ -8,6 +8,7 @@ import org.testng.*;
 
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
+import java.util.Map;
 
 public class DemoProjectListener implements ISuiteListener, IInvokedMethodListener2 {
     @Override
@@ -34,9 +35,13 @@ public class DemoProjectListener implements ISuiteListener, IInvokedMethodListen
 
     @Override
     public void onStart(ISuite suite) {
-        WebDriverManager.firefoxdriver().setup();
-        Configuration.browser = "firefox";
-        Configuration.browserBinary = System.getenv("FIREFOX_BINARY");
+        Configuration.browser = System.getProperty("selenide.browser", "firefox");
+        Map.of("firefox", WebDriverManager.firefoxdriver(),
+                "chrome", WebDriverManager.chromedriver(),
+                "edge", WebDriverManager.edgedriver(),
+                "phantomjs", WebDriverManager.phantomjs())
+                .get(Configuration.browser)
+                .setup();
         Configuration.timeout = 15000;
     }
 

--- a/src/test/java/com/demo/project/ui/TestBase.java
+++ b/src/test/java/com/demo/project/ui/TestBase.java
@@ -10,7 +10,7 @@ import static com.codeborne.selenide.Selenide.open;
 
 @Accessors(fluent = true)
 @Getter
-public class TestBase {
+public abstract class TestBase {
 
     private final LoginPage loginPage = new LoginPage();
     private final DashboardPage dashboardPage = new DashboardPage();

--- a/src/test/resources/testSuites/PresentationSuite.xml
+++ b/src/test/resources/testSuites/PresentationSuite.xml
@@ -4,7 +4,7 @@
 
 
     <listeners>
-        <listener class-name="com.demo.project.listeners.DemoProjectListener"></listener>
+        <listener class-name="com.demo.project.listeners.DemoProjectListener"/>
     </listeners>
 
     <test name="Poprawne zalogowanie się do aplikacji jako admin biznesowy">


### PR DESCRIPTION
Browser binary setup is now not needed, webdrivermanager should take care of of setting webdriver whatever is assigned - default is firefox like in previous version. I suggest chaning it to Chrome in the future.
Additionally - cleanup in pom - dependencies version moved to properties.
Moved suites to test resources, and expanded readme.